### PR TITLE
Prevent resource leaks

### DIFF
--- a/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/JarFileIO.java
+++ b/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/JarFileIO.java
@@ -47,9 +47,9 @@ public class JarFileIO {
 			
 			Path tmpFile = Paths.get(tempDir.toString()+"/"+file);
 			Files.createDirectories(tmpFile.getParent());
-			OutputStream stream = Files.newOutputStream(tmpFile, StandardOpenOption.CREATE);
-			stream.write(bytes);
-			stream.close();
+			try (final OutputStream stream = Files.newOutputStream(tmpFile, StandardOpenOption.CREATE)) {
+				stream.write(bytes);
+			}
 			String command = "jar uf " + outputJar + " -C " + tempDir.toString() + " " + file;
 			Process p = Runtime.getRuntime().exec(command);
 			p.waitFor();

--- a/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Options.java
+++ b/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Options.java
@@ -1,5 +1,6 @@
 package edu.cmu.sv.kelinci.instrumentor;
 
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.io.File;
 import java.io.IOException;
@@ -8,6 +9,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.kohsuke.args4j.Option;
 
@@ -70,9 +72,9 @@ public class Options {
 			dirprefix = input.length();
 		else
 			dirprefix = input.length()+1;
-		
-		try {
-			Files.walk(Paths.get(input)).filter(Files::isRegularFile).forEach(filePath -> {
+
+		try (Stream<Path> stream = Files.walk(Paths.get(input))) {
+			stream.filter(Files::isRegularFile).forEach(filePath -> {
 				String name = filePath.toString();
 				System.out.println("Found file " + name);
 				if (name.endsWith(".class")) {


### PR DESCRIPTION
- The output stream would not have been closed when an exception happened while writing the bytes
- The stream from Files.walk needs to be explicitly closed otherwise the handle remains open