### PR TITLE
Fix classloader to also allow instrumentation of e.g. commons-io version 2.6 

### DIFF
--- a/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Instrumentor.java
+++ b/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Instrumentor.java
@@ -2,6 +2,8 @@ package edu.cmu.sv.kelinci.instrumentor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -27,7 +29,7 @@ public class Instrumentor {
 	public static void main(String[] args) {
 	
 		// get class loader
-		classloader = Thread.currentThread().getContextClassLoader();
+		classloader = new URLClassLoader(new URL[] {}, null);
 		
 		// parse command line arguments
 		Options options = Options.v();
@@ -130,6 +132,9 @@ public class Instrumentor {
 
 	private static void loadAndWriteResource(String resource) {
 		InputStream is = classloader.getResourceAsStream(resource);
+		if (is == null) {
+			is = ClassLoader.getSystemResourceAsStream(resource);
+		}
 		if (is == null) {
 			System.err.println("Error loading Kelinci classes for addition to output");
 			return;

--- a/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Options.java
+++ b/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Options.java
@@ -57,7 +57,7 @@ public class Options {
 			File file = new File(url);
 			Method method = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
 			method.setAccessible(true);
-		    method.invoke(ClassLoader.getSystemClassLoader(), new Object[]{file.toURI().toURL()});
+		    method.invoke(Instrumentor.classloader, new Object[]{file.toURI().toURL()});
 		} catch (Exception e) {
 			throw new RuntimeException("Error adding location to class path: " + url);
 		}

--- a/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Options.java
+++ b/instrumentor/src/main/java/edu/cmu/sv/kelinci/instrumentor/Options.java
@@ -57,7 +57,8 @@ public class Options {
 			File file = new File(url);
 			Method method = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
 			method.setAccessible(true);
-		    method.invoke(Instrumentor.classloader, new Object[]{file.toURI().toURL()});
+			method.invoke(Instrumentor.classloader, new Object[]{file.toURI().toURL()});
+			method.invoke(ClassLoader.getSystemClassLoader(), new Object[]{file.toURI().toURL()});
 		} catch (Exception e) {
 			throw new RuntimeException("Error adding location to class path: " + url);
 		}


### PR DESCRIPTION
When you try to instrument commons-io version 2.6 with kelinci it will output the instrumented version of its dependency version of commons-io.
This pull request fixes the classloader so that you can also instrument commons-io version 2.6