### PR TITLE
server mainloop: use LinkedBlockingQueue instead of ConcurrentLinkedQueue

### DIFF
--- a/instrumentor/src/main/java/edu/cmu/sv/kelinci/Kelinci.java
+++ b/instrumentor/src/main/java/edu/cmu/sv/kelinci/Kelinci.java
@@ -14,12 +14,12 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.Arrays;
-import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeoutException;
 class Kelinci {
 
 	private static final int maxQueue = 10;
-	private static Queue<FuzzRequest> requestQueue = new ConcurrentLinkedQueue<>();
+	private static BlockingQueue<FuzzRequest> requestQueue = new LinkedBlockingQueue<>();
 
 	public static final byte STATUS_SUCCESS = 0;
 	public static final byte STATUS_TIMEOUT = 1;
@@ -184,7 +184,7 @@ class Kelinci {
 		
 		while (true) {
 			try {
-				FuzzRequest request = requestQueue.poll();
+				FuzzRequest request = requestQueue.poll(1000, TimeUnit.MILLISECONDS);
 				if (request != null) {
 					if (verbosity > 1)
 						System.out.println("Handling request 1 of " + (requestQueue.size()+1));
@@ -327,9 +327,6 @@ class Kelinci {
 					if (verbosity > 1) 
 						System.out.println("Connection closed.");
 
-				} else {
-					// if no request, close your eyes for a bit
-					Thread.sleep(100);
 				}
 			} catch (SocketException se) {
 				// Connection was reset, most probably means AFL process was killed.


### PR DESCRIPTION
`ConcurrentLinkedQueue`, having no waiting ability, lead to the use of a homebrew spinlock with a sleep time of 100ms. This meant that if the fuzzer couldn't supply the server with another request immediately (with only one fuzzin instance it never can), it would incur a 100ms wait, which would have the effect of throttling the fuzzing throughput to 10/s.

This patch raises my fuzzing rate to ~100/s.